### PR TITLE
fix: dockercompose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - .env # Your app configs (no secrets here)
+      - .env               # Your app configs (no secrets here)
     depends_on:
       - auth-service
       - user-service
@@ -18,7 +18,6 @@ services:
       - ppob-service
       - payment-service
       - transaction-service
-      - trains-service
     networks:
       - tiketq-net
     restart: unless-stopped
@@ -29,8 +28,8 @@ services:
     container_name: auth-service
     ports:
       - "8001:8000" # temporary expose for testing
-    environment:
-      - AUTH_DB_URL=postgresql://postgres:postgres@postgres:5432/tiketq_db
+    env_file:
+      - .env
     networks:
       - tiketq-net
     restart: unless-stopped
@@ -39,8 +38,8 @@ services:
     build:
       context: ./user-service
     container_name: user-service
-    environment:
-      - USER_DB_URL=postgresql://postgres:postgres@postgres:5432/tiketq_db
+    env_file:
+      - .env
     networks:
       - tiketq-net
     restart: unless-stopped
@@ -91,16 +90,8 @@ services:
     container_name: transaction-service
     ports:
       - "8004:8000" # temporary expose e.g. localhost:8004/docs
-    environment:
-      - TRANSACTION_DB_URL=postgresql://postgres:postgres@postgres:5432/tiketq_db
-    networks:
-      - tiketq-net
-    restart: unless-stopped
-
-  trains-service:
-    build:
-      context: ./trains-service
-    container_name: trains-service
+    env_file:
+      - .env
     networks:
       - tiketq-net
     restart: unless-stopped
@@ -110,15 +101,18 @@ services:
     container_name: postgres
     environment:
       POSTGRES_DB: tiketq_db
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER_FILE: /run/secrets/db_user
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     ports:
-      - "5433:5432"
+      - "5432:5432"
     networks:
       - tiketq-net
+    secrets:
+      - db_user
+      - db_password
     restart: unless-stopped
 
   nginx:
@@ -131,6 +125,12 @@ services:
     networks:
       - tiketq-net
     restart: unless-stopped
+
+secrets:
+  db_user:
+    file: ./secrets/db_user.txt
+  db_password:
+    file: ./secrets/db_password.txt
 
 networks:
   tiketq-net:


### PR DESCRIPTION
Revert dockercompose content to original state to utilize secrets folder and .env