### PR TITLE
feat: add admin access to transaction details

### DIFF
--- a/transaction-service/domain/services.py
+++ b/transaction-service/domain/services.py
@@ -147,7 +147,7 @@ class TransactionService:
             logger.error(f"Error creating transaction: {str(e)}", exc_info=True)
             return None
     
-    def get_transaction(self, transaction_id: int, email: str) -> Optional[TransactionInDB]:
+    def get_transaction(self, transaction_id: int, email: str, role: UserRole) -> Optional[TransactionInDB]:
         """Get a transaction by ID with authorization check.
         
         Args:
@@ -159,9 +159,12 @@ class TransactionService:
         """
         try:
             transaction = self.transaction_repo.get_transaction(transaction_id)
-            if not transaction or transaction.email != email:
-                return None
-            return transaction
+            if role == UserRole.ADMIN and transaction:
+                return transaction
+            else:
+                if not transaction or transaction.email != email:
+                    return None
+                return transaction
         except Exception as e:
             logger.error(f"Error retrieving transaction {transaction_id}: {str(e)}")
             return None

--- a/transaction-service/routes/transactions.py
+++ b/transaction-service/routes/transactions.py
@@ -1,3 +1,4 @@
+from math import log
 from fastapi import APIRouter, Depends, HTTPException, status, Body, Request
 from typing import List, Optional
 from sqlalchemy.orm import Session
@@ -371,7 +372,8 @@ async def get_transaction(
         
         transaction = service.get_transaction(
             transaction_id=transaction_id,
-            email=current_user.email
+            email=current_user.email,
+            role=current_user.role
         )
         
         if not transaction:


### PR DESCRIPTION
- Modified TransactionService.get_transaction() to accept a role parameter
- Added role-based access control:
  - Admins can view any transaction
  - Regular users can only view their own transactions
- Updated the transaction endpoint to pass the user's role