### PR TITLE
refactor: remove email-based authorization from service layer

### DIFF
--- a/transaction-service/domain/services.py
+++ b/transaction-service/domain/services.py
@@ -217,6 +217,7 @@ class TransactionService:
                 return transaction
             else:
                 if not transaction or transaction.email != email:
+                    logger.info(f"Unauthorized access to transaction {transaction_id} - User: {email}")
                     return None
                 return transaction
         except Exception as e:
@@ -355,7 +356,6 @@ class TransactionService:
         self, 
         transaction_id: int, 
         update_request: TransactionUpdateRequest,
-        email: str
     ) -> Optional[TransactionInDB]:
         """Update transaction with validated request model.
         
@@ -372,7 +372,7 @@ class TransactionService:
         """
         try:
             transaction_check = self.transaction_repo.get_transaction(transaction_id)
-            if not transaction_check or transaction_check.email != email:
+            if not transaction_check:
                 raise ValueError("Transaction not found or access denied")
 
             # Create update data from validated request
@@ -403,10 +403,9 @@ class TransactionService:
             if updated_transaction:
                 logger.info(
                     f"Transaction updated successfully - ID: {transaction_id}, "
-                    f"Email: {email}, "
                     f"Status changed: {original_transaction.status.value if original_transaction.status else 'None'} -> "
                     f"{updated_transaction.status.value if updated_transaction.status else 'None'}, "
-                    f"Order: {original_transaction.order_id}, "
+                    f"Order: {original_transaction.order_number}, "
                     f"Amount: {original_transaction.amount}, "
                     f"Changes: {update_data}"
                 )
@@ -416,7 +415,7 @@ class TransactionService:
             logger.error(f"Error updating transaction {transaction_id}: {str(e)}")
             return None
     
-    def cancel_transaction(self, transaction_id: int, email: str) -> Optional[TransactionInDB]:
+    def cancel_transaction(self, transaction_id: int) -> Optional[TransactionInDB]:
         """Cancel a transaction with logging"""
         try:
             from domain.models import TransactionStatus
@@ -424,14 +423,14 @@ class TransactionService:
             # Create an update request to set status to cancelled
             cancel_request = TransactionUpdateRequest(status=TransactionStatus.CANCELLED)
             
-            result = self.update_transaction(transaction_id, cancel_request, email)
+            result = self.update_transaction(transaction_id, cancel_request)
             
             if result:
-                logger.info(f"Transaction cancelled: transaction_id={transaction_id}, email={email}")
+                logger.info(f"Transaction cancelled: transaction_id={transaction_id}")
                 
             return result
         except Exception as e:
-            logger.error(f"Failed to cancel transaction {transaction_id} for user {email}: {str(e)}")
+            logger.error(f"Failed to cancel transaction {transaction_id}: {str(e)}")
             raise
     
     # Delete transaction with authorization check (should be admin)
@@ -456,7 +455,7 @@ class OrderService:
     ):
         self.order_repo = order_repo
     
-    def get_order(self, order_id: int, email: Optional[str] = None) -> Optional[OrderInDB]:
+    def get_order(self, order_id: int) -> Optional[OrderInDB]:
         """Get an order by ID with optional authorization check.
         
         Args:
@@ -470,14 +469,7 @@ class OrderService:
             order = self.order_repo.get_order(order_id)
             if not order:
                 return None
-                
-            # If email is provided, verify the order belongs to this user
-            if email is not None and order.email != email:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Access denied to this order"
-                )
-                
+
             return order
             
         except Exception as e:
@@ -620,7 +612,6 @@ class OrderService:
         self, 
         order_id: int, 
         status_request: "OrderStatusUpdateRequest",
-        email: str
     ) -> Optional[OrderInDB]:
         """Update order status with Pydantic validation.
         
@@ -636,10 +627,6 @@ class OrderService:
             ValueError: If validation fails or unauthorized access
         """
         try:
-            order_check = self.order_repo.get_order(order_id)
-            if not order_check or order_check.email != email:
-                raise ValueError("Order not found or access denied")
-                
             # Create update data from validated request
             update_data = {
                 "status": status_request.status

--- a/transaction-service/routes/orders.py
+++ b/transaction-service/routes/orders.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 
 from domain.models import (
     OrderInDB, OrderStatus,
-    OrderCreateRequest, OrderStatusUpdateRequest
+    OrderCreateRequest, OrderStatusUpdateRequest,
+    UserRole
 )
 from domain.services import (
     OrderService,
@@ -13,6 +14,10 @@ from domain.services import (
     require_admin,
     require_user_or_admin
 )
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["orders"])
 
@@ -93,7 +98,6 @@ async def get_order(
     try:
         order = service.get_order(
             order_id=order_id,
-            email=current_user.email
         )
         
         if not order:
@@ -103,7 +107,7 @@ async def get_order(
             )
         
         # Check access rights - users can only see their own orders
-        if current_user.role != "admin" and order.email != current_user.email:
+        if current_user.role != UserRole.ADMIN and order.email != current_user.email:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied to this order"
@@ -178,9 +182,10 @@ async def update_order_status(
         # Check if order exists
         existing_order = service.get_order(
             order_id=order_id,
-            email=current_user.email  # Admin can access any order
         )
-        
+
+        logger.info("Existing order: %s", existing_order)
+
         if not existing_order:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -191,7 +196,6 @@ async def update_order_status(
         updated_order = service.update_order_status(
             order_id=order_id,
             status_request=status_request,
-            email=current_user.email
         )
         
         if not updated_order:

--- a/transaction-service/routes/payments.py
+++ b/transaction-service/routes/payments.py
@@ -30,11 +30,11 @@ def get_payment_service(db: Session = Depends(get_database_session)) -> PaymentS
 
 
 @router.get(
-    "/payments/{payment_id}", 
+    "/payments/{order_number}", 
     response_model=PaymentInDB,
-    summary="Get payment details by ID",
+    summary="Get transaction payment details by order number",
     description="""
-    Retrieve details of a specific payment by its ID.
+    Retrieve details of a specific payment by its order number.
     
     ### Access Level: User/Admin
     - Requires authentication
@@ -43,24 +43,26 @@ def get_payment_service(db: Session = Depends(get_database_session)) -> PaymentS
     """
 )
 async def get_payment_details(
-    payment_id: int,
+    order_number: str,
     current_user = Depends(require_user_or_admin),
     payment_service: PaymentService = Depends(get_payment_service)
 ):
     """Get payment details - USER/ADMIN access"""
     try:
-        payment = payment_service.payment_repo.get_payment(payment_id)
+        payment = payment_service.payment_repo.get_payment_by_order_number(order_number)
         
         if not payment:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Payment not found"
             )
-        
+        logger.info("Payment found: %s", payment)
         # Check authorization - users can only see their own payments
         if current_user.role != UserRole.ADMIN:
             # Get associated transaction to check user ownership
+            logger.info("Checking user authorization for payment %s", payment.transaction_id)
             transaction = payment_service.transaction_repo.get_transaction(payment.transaction_id)
+            logger.info("Transaction found: %s", transaction)
             if not transaction or transaction.email != current_user.email:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
@@ -80,9 +82,9 @@ async def get_payment_details(
 @router.post(
     "/payments/{order_number}/confirm",
     response_model=PaymentInDB,
-    summary="Confirm a payment",
+    summary="Confirm a transaction payment",
     description="""
-    Confirm a payment that was initiated.
+    Confirm a transaction payment that was initiated.
     
     ### Access Level: Public (with token)
     - Used to confirm successful payments

--- a/transaction-service/routes/transactions.py
+++ b/transaction-service/routes/transactions.py
@@ -215,9 +215,10 @@ async def create_transaction(
     description="""
     Retrieve a list of transactions.
     
-    ### Access Level: Admin Only
-    - Requires admin privileges
-    - Regular users cannot access this endpoint
+    ### Access Level: User/Admin
+    - Requires authentication
+    - Users can only see their own transactions
+    - Admins can see all transactions
     """
 )
 async def list_transactions(
@@ -489,9 +490,10 @@ async def update_transaction(
         # First check if transaction exists and user has access
         existing_transaction = service.get_transaction(
             transaction_id=transaction_id,
-            email=current_user.email
+            email=current_user.email,
+            role=current_user.role
         )
-        
+
         if not existing_transaction:
             # Log unauthorized access
             audit_logger.log_security_event(
@@ -516,7 +518,6 @@ async def update_transaction(
         updated_transaction = service.update_transaction(
             transaction_id=transaction_id,
             update_request=update_request,
-            email=current_user.email
         )
         
         if not updated_transaction:
@@ -647,7 +648,8 @@ async def cancel_transaction(
         # First check if transaction exists and user has access
         existing_transaction = service.get_transaction(
             transaction_id=transaction_id,
-            email=current_user.email
+            email=current_user.email,
+            role=current_user.role
         )
         
         if not existing_transaction:
@@ -721,7 +723,6 @@ async def cancel_transaction(
         cancelled_transaction = service.update_transaction(
             transaction_id=transaction_id,
             update_request=cancel_request,
-            email=current_user.email
         )
         
         if not cancelled_transaction:


### PR DESCRIPTION
- Remove email parameter from service methods (update_transaction, cancel_transaction, get_order, update_order_status)
- Move authorization checks to route handlers for better separation of concerns
- Add comprehensive logging for payment and order operations
- Update payment endpoint to use order_number instead of payment_id
- Improve transaction and order status update logging
- Fix order_number reference in transaction logging
- Update access level documentation for transaction listing endpoint
- Add logging for better debugging of payment authorization flow